### PR TITLE
Libi2c fix for #12

### DIFF
--- a/functions/MLX90640_LINUX_I2C_Driver.cpp
+++ b/functions/MLX90640_LINUX_I2C_Driver.cpp
@@ -21,7 +21,13 @@
 #include <fcntl.h>
 #include <string.h>
 #include <linux/i2c-dev.h>
+
+#define I2C_MSG_FMT char
+#ifndef I2C_FUNC_I2C
 #include <linux/i2c.h>
+#define I2C_MSG_FMT __u8
+#endif
+
 #include <sys/ioctl.h>
 
 int i2c_fd = 0;
@@ -48,12 +54,12 @@ int MLX90640_I2CRead(uint8_t slaveAddr, uint16_t startAddress, uint16_t nMemAddr
     i2c_messages[0].addr = slaveAddr;
     i2c_messages[0].flags = 0;
     i2c_messages[0].len = 2;
-    i2c_messages[0].buf = (__u8*)cmd;
+    i2c_messages[0].buf = (I2C_MSG_FMT*)cmd;
 
     i2c_messages[1].addr = slaveAddr;
     i2c_messages[1].flags = I2C_M_RD | I2C_M_NOSTART;
     i2c_messages[1].len = nMemAddressRead * 2;
-    i2c_messages[1].buf = (__u8*)buf;
+    i2c_messages[1].buf = (I2C_MSG_FMT*)buf;
 
     //result = write(i2c_fd, cmd, 3);    
     //result = read(i2c_fd, buf, nMemAddressRead*2);
@@ -90,7 +96,7 @@ int MLX90640_I2CWrite(uint8_t slaveAddr, uint16_t writeAddress, uint16_t data)
     i2c_messages[0].addr = slaveAddr;
     i2c_messages[0].flags = 0;
     i2c_messages[0].len = 4;
-    i2c_messages[0].buf = (__u8*)cmd;
+    i2c_messages[0].buf = (I2C_MSG_FMT*)cmd;
 
     i2c_messageset[0].msgs = i2c_messages;
     i2c_messageset[0].nmsgs = 1;


### PR DESCRIPTION
This aims to fix an issue with `make I2C_MODE=linux` raised in shop comments and issue #12 where having `libi2c-dev` installed could cause duplicate function definitions, but removing it would allow a successful build.

It checks for a defined value in the `libi2c-dev` version of `linux/i2c-dev.h` and skips inclusion of `linux/i2c.h` where it's not required. This also necessitates the switching between `char` and `unsigned char` which is rather unsightly, but there doesn't seem to be a good way around this.

My preference, if all else fails, would be to support compiling with `libi2c-dev` installed, since this library may be required for other projects.