### PR TITLE
Add commandline parameters to set more options: filename, rawrgb location, rotation. Create one frame

### DIFF
--- a/python/rgb-to-gif.py
+++ b/python/rgb-to-gif.py
@@ -8,9 +8,12 @@ import os
 
 MAX_FRAMES = 50           # Large sizes get big quick!
 SKIP_FRAMES = 2           # Frames to skip before starting recording
-OUTPUT_SIZE = (240, 320)  # Multiple of (24, 32)
+OUTPUT_SIZE = (24, 32)  # Multiple of (24, 32)
 FPS = 4                   # Should match the FPS value in examples/rawrgb.cpp
 RAW_RGB_PATH = "../examples/rawrgb"
+FILE_NAME ='mlx90640-{}.gif'.format(datetime.now().strftime("%Y-%m-%d-%H-%M-%S"))
+ROTATE = 270
+
 
 frames = []
 
@@ -19,14 +22,27 @@ parser.add_argument('--frames', type=int, help='Number of frames to capture.', d
 parser.add_argument('--fps', type=int, help='Framerate to capture. Default: 4',
                     choices=[1, 2, 4, 8, 16, 32, 64], default=FPS)
 parser.add_argument('--skip', type=int, help='Frames to skip. Default: 2', default=SKIP_FRAMES)
+parser.add_argument('--rawrgb',type=str, help="enter path of the rawrgb location. Default: ../examples/rawrgb", default=RAW_RGB_PATH)
+parser.add_argument('--name',type=str, help="enter path and filename.", default=FILE_NAME)
+parser.add_argument('--rotate',type=int, help="enter rotation of picture. Default: 270 degrees", default=ROTATE)
 args = parser.parse_args()
 
 fps = args.fps
 max_frames = args.frames
 skip_frames = args.skip
+rawrgb_path = args.rawrgb
+name = args.name
+if args.rotate < 180:
+    rotation = Image.ROTATE_90
+elif args.rotate < 270:
+    rotation = Image.ROTATE_180
+elif args.rotate < 360:
+    rotation = Image.ROTATE_270
 
-if not os.path.isfile(RAW_RGB_PATH):
-    raise RuntimeError("{} doesn't exist, did you forget to run \"make\"?".format(RAW_RGB_PATH))
+
+
+if not os.path.isfile(rawrgb_path):
+    raise RuntimeError("{} doesn't exist, did you forget to run \"make\"?".format(rawrgb_path))
 
 print("""rgb-to-gif.py - output a gif using ./rawrgb command.
 
@@ -40,7 +56,7 @@ Press Ctrl+C to save & exit!
 """)
 
 try:
-    with subprocess.Popen(["sudo", RAW_RGB_PATH, "{}".format(fps)], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as camera:
+    with subprocess.Popen(["sudo", rawrgb_path, "{}".format(fps)], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as camera:
         while True:
             # Despite the docs, we use read() here since we want to poll
             # the process for chunks of 2304 bytes, each of which is a frame
@@ -75,12 +91,11 @@ finally:
         for index, image in enumerate(frames):
             image = image.convert('P', dither=False, palette=master.palette)
             # image = image.quantize(method=3, palette=master)
-            image = image.transpose(Image.ROTATE_270).transpose(Image.FLIP_LEFT_RIGHT)
+            image = image.transpose(rotation).transpose(Image.FLIP_LEFT_RIGHT)
             image = image.resize(OUTPUT_SIZE, Image.NEAREST)
             frames[index] = image
 
-        filename = 'mlx90640-{}.gif'.format(
-            datetime.now().strftime("%Y-%m-%d-%H-%M-%S"))
+        filename = name
         print("Saving {} with {} frames.".format(filename, len(frames)))
         frames[0].save(
             filename,
@@ -89,5 +104,18 @@ finally:
             duration=1000 // fps,
             loop=0,
             include_color_table=True,
+            optimize=True,
+            palette=master.palette.getdata())
+
+    elif len(frames) == 1:
+        master = Image.new('RGB', (32, 24))
+        master = master.convert('P', dither=False, palette=Image.ADAPTIVE, colors=256)
+        image = image.transpose(rotation).transpose(Image.FLIP_LEFT_RIGHT)
+        image = image.resize(OUTPUT_SIZE, Image.NEAREST)
+
+        filename = name
+        print("Saving {} as jpeg.".format(filename))
+        frames[0].save(
+            filename,
             optimize=True,
             palette=master.palette.getdata())


### PR DESCRIPTION
With commandline parameters you can easily adapt the following parameters:
rawrgb: enter path of the rawrgb location. Default: ../examples/rawrgb"
name  : enter path and filename of the image generated.
rotate: enter rotation of picture. Default: 270 degrees

Also you can now create also one frame and choose to make that a JPG