### PR TITLE
Removed print statements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ examples = test rawrgb step fbuf interp video hotspot sdlscale
 examples_objects = $(addsuffix .o,$(addprefix $(SRC_DIR), $(examples)))
 examples_output = $(addprefix $(BUILD_DIR), $(examples))
 
+#debugging enabled by default
+CXXFLAGS+=-DDEBUG -g
+
 #PREFIX is environment variable, but if it is not set, then set default value
 ifeq ($(PREFIX),)
 	PREFIX = /usr/local

--- a/functions/MLX90640_API.cpp
+++ b/functions/MLX90640_API.cpp
@@ -139,7 +139,9 @@ int MLX90640_GetFrameData(uint8_t slaveAddr, uint16_t *frameData)
 	auto t_end = std::chrono::system_clock::now();
 	auto t_elapsed = std::chrono::duration_cast<std::chrono::seconds>(t_end - t_start);
 	if (t_elapsed.count() > 5) {
-		printf("frameData timeout error waiting for dataReady \n");
+		#ifdef DEBUG
+        printf("frameData timeout error waiting for dataReady \n");
+        #endif
 		return -1;
 	}
     } 
@@ -153,11 +155,13 @@ int MLX90640_GetFrameData(uint8_t slaveAddr, uint16_t *frameData)
         }
 
         error = MLX90640_I2CRead(slaveAddr, 0x0400, 832, frameData); 
+        #ifdef DEBUG
         if(error != 0)
         {
             printf("frameData read error \n");
             return error;
         }
+        #endif
 
         error = MLX90640_I2CRead(slaveAddr, 0x8000, 1, &statusRegister);
         if(error != 0)
@@ -168,11 +172,13 @@ int MLX90640_GetFrameData(uint8_t slaveAddr, uint16_t *frameData)
         cnt = cnt + 1;
     }
 
+    #ifdef DEBUG
     if(cnt > 4)
     {
         fprintf(stderr, "cnt > 4 error \n");
         // return -8;
     }
+    #endif
     //printf("count: %d \n", cnt); 
     error = MLX90640_I2CRead(slaveAddr, 0x800D, 1, &controlRegister1);
     frameData[832] = controlRegister1;

--- a/functions/MLX90640_LINUX_I2C_Driver.cpp
+++ b/functions/MLX90640_LINUX_I2C_Driver.cpp
@@ -69,7 +69,9 @@ int MLX90640_I2CRead(uint8_t slaveAddr, uint16_t startAddress, uint16_t nMemAddr
     memset(buf, 0, nMemAddressRead * 2);
 
     if (ioctl(i2c_fd, I2C_RDWR, &i2c_messageset) < 0) {
+        #ifdef DEBUG
         printf("I2C Read Error!\n");
+        #endif
         return -1;
     }
 
@@ -102,7 +104,9 @@ int MLX90640_I2CWrite(uint8_t slaveAddr, uint16_t writeAddress, uint16_t data)
     i2c_messageset[0].nmsgs = 1;
 
     if (ioctl(i2c_fd, I2C_RDWR, &i2c_messageset) < 0) {
+        #ifdef DEBUG
         printf("I2C Write Error!\n");
+        #endif
         return -1;
     }
 


### PR DESCRIPTION
This PR removes print statements throughout this library.

These statements are an issue because they flood and clutter the console making it difficult for users to interface with console based applications linking this library.

Putting print statements inside a library is also considered bad code practice and should be avoided: [https://softwareengineering.stackexchange.com/questions/317226/should-there-be-print-statements-in-a-library](https://softwareengineering.stackexchange.com/questions/317226/should-there-be-print-statements-in-a-library)


While I understand that these messages may be useful to people debugging, they are rather obnoxious for production applications. If removing these statements is not an option, would it be possible for this library to make these statements togglable in any way?